### PR TITLE
Update to swift 5

### DIFF
--- a/HGPlaceholders/Classes/Placeholder/PlaceholderKey.swift
+++ b/HGPlaceholders/Classes/Placeholder/PlaceholderKey.swift
@@ -47,9 +47,9 @@ public struct PlaceholderKey: Hashable {
         return PlaceholderKey(value: key)
     }
     
-    public var hashValue: Int {
-        return value.hashValue
-    }
+    public func hash(into hasher: inout Hasher) {
+		hasher.combine(value)
+	}
 }
 
 extension PlaceholderKey: Equatable {


### PR DESCRIPTION
'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'PlaceholderKey' to 'Hashable' by implementing 'hash(into:)' instead

*Please make sure that I've implemented that right.