### PR TITLE
Make sure `tableViewHeight` isn't less then 0.0 to prevent crash

### DIFF
--- a/HGPlaceholders/Classes/PlaceholdersProvider/PlaceholderDataSourceDelegate.swift
+++ b/HGPlaceholders/Classes/PlaceholdersProvider/PlaceholderDataSourceDelegate.swift
@@ -151,7 +151,8 @@ extension PlaceholderDataSourceDelegate: UITableViewDelegate {
         if style?.shouldShowTableViewFooter != true {
             tableViewHeight -= tableView.tableFooterView?.bounds.height ?? 0
         }
-        
+        // Make sure tableViewHeight isn't less then 0.0 to prevent crash
+        tableViewHeight = tableViewHeight >= 0.0 ? tableViewHeight : 0
         return tableViewHeight
     }
     

--- a/HGPlaceholders/Classes/Protocols/NibLoadable.swift
+++ b/HGPlaceholders/Classes/Protocols/NibLoadable.swift
@@ -16,7 +16,7 @@ import UIKit
  *
  * to be able to instantiate them from the NIB in a type-safe manner
  */
-protocol NibLoadable: class {
+protocol NibLoadable: AnyObject {
     /// The nib file to use to load a new instance of the View designed in a XIB
     static var nib: UINib { get }
 }

--- a/HGPlaceholders/Classes/Protocols/Reusable.swift
+++ b/HGPlaceholders/Classes/Protocols/Reusable.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Make your `UITableViewCell` and `UICollectionViewCell` subclasses
 /// conform to this protocol to be able to dequeue them in a type-safe manner
-protocol Reusable: class {
+protocol Reusable: AnyObject {
     /// The reuse identifier to use when registering and later dequeuing a reusable cell
     static var reuseIdentifier: String { get }
 }

--- a/HGPlaceholders/Classes/Views/TableView.swift
+++ b/HGPlaceholders/Classes/Views/TableView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 
 /// The delegate of a TableView/CollectionView object must adopt the PlaceholderDelegate protocol. the method of the protocol allow the delegate to perform placeholders action.
-public protocol PlaceholderDelegate: class {
+public protocol PlaceholderDelegate: AnyObject {
     
     /// Performs the action to the delegate of the table or collection view
     ///


### PR DESCRIPTION
Fix #51 
From some reason, the fix I've tried a long time ago with iOS 13 and didn't work, now working with iOS 15.